### PR TITLE
Explicitly initialize all pointer members to nullptr

### DIFF
--- a/components/virtual_can_bms/virtual_can_bms.h
+++ b/components/virtual_can_bms/virtual_can_bms.h
@@ -97,16 +97,16 @@ class VirtualCanBms : public PollingComponent {
   canbus::Canbus *canbus;
 
  protected:
-  sensor::Sensor *charge_voltage_sensor_;
-  sensor::Sensor *charge_current_limit_sensor_;
-  sensor::Sensor *discharge_current_limit_sensor_;
-  sensor::Sensor *discharge_voltage_limit_sensor_;
-  sensor::Sensor *state_of_charge_sensor_;
-  sensor::Sensor *state_of_health_sensor_;
-  sensor::Sensor *hires_state_of_charge_sensor_;
-  sensor::Sensor *battery_voltage_sensor_;
-  sensor::Sensor *battery_current_sensor_;
-  sensor::Sensor *battery_temperature_sensor_;
+  sensor::Sensor *charge_voltage_sensor_{nullptr};
+  sensor::Sensor *charge_current_limit_sensor_{nullptr};
+  sensor::Sensor *discharge_current_limit_sensor_{nullptr};
+  sensor::Sensor *discharge_voltage_limit_sensor_{nullptr};
+  sensor::Sensor *state_of_charge_sensor_{nullptr};
+  sensor::Sensor *state_of_health_sensor_{nullptr};
+  sensor::Sensor *hires_state_of_charge_sensor_{nullptr};
+  sensor::Sensor *battery_voltage_sensor_{nullptr};
+  sensor::Sensor *battery_current_sensor_{nullptr};
+  sensor::Sensor *battery_temperature_sensor_{nullptr};
 
   void send_frame_0x0351_();
   void send_frame_0x0355_();

--- a/components/virtual_can_bms/virtual_can_bms.h
+++ b/components/virtual_can_bms/virtual_can_bms.h
@@ -94,7 +94,7 @@ class VirtualCanBms : public PollingComponent {
 
   float get_setup_priority() const override { return setup_priority::DATA; }
 
-  canbus::Canbus *canbus;
+  canbus::Canbus *canbus{nullptr};
 
  protected:
   sensor::Sensor *charge_voltage_sensor_{nullptr};


### PR DESCRIPTION
## Summary
- Add `{nullptr}` in-class initializer to all raw pointer members in component header files that previously had no initializer
- Aligns with ESPHome core style: every component in the ESPHome core uses `{nullptr}` for pointer members — no uninitialized pointer exists in the core codebase
- While ESPHome instantiates components via `new T()` (value-initializes to zero), explicit `{nullptr}` makes the intent unambiguous and matches the upstream convention