### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/virtual_can_bms/virtual_can_bms.cpp
+++ b/components/virtual_can_bms/virtual_can_bms.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace virtual_can_bms {
+namespace esphome::virtual_can_bms {
 
 static const char *const TAG = "virtual_can_bms";
 
@@ -131,5 +130,4 @@ void VirtualCanBms::send_frame_0x035a_() {
   this->canbus->send_data(0x035A, false, false, std::vector<uint8_t>(ptr, ptr + sizeof message));
 }
 
-}  // namespace virtual_can_bms
-}  // namespace esphome
+}  // namespace esphome::virtual_can_bms

--- a/components/virtual_can_bms/virtual_can_bms.h
+++ b/components/virtual_can_bms/virtual_can_bms.h
@@ -4,8 +4,7 @@
 #include "esphome/components/canbus/canbus.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace virtual_can_bms {
+namespace esphome::virtual_can_bms {
 
 struct SmaCanMessage0x0351 {
   uint16_t ChargeVoltage;          // U16
@@ -115,5 +114,4 @@ class VirtualCanBms : public PollingComponent {
   void publish_state_(sensor::Sensor *sensor, float value);
 };
 
-}  // namespace virtual_can_bms
-}  // namespace esphome
+}  // namespace esphome::virtual_can_bms


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.