### PR TITLE
Add C++ unit tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,8 @@ jobs:
         run: |
           cd esphome
           cp -r ../components/* esphome/components/
+          mkdir -p tests/components/virtual_can_bms
+          cp -r ../tests/components/virtual_can_bms/* tests/components/virtual_can_bms/
           git config user.name "ci"
           git config user.email "ci@github.com"
           git add .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -419,6 +419,54 @@ jobs:
           . venv/bin/activate
           pytest tests/ -v
 
+  cpp-unit-tests:
+    name: Run C++ unit tests
+    runs-on: ubuntu-24.04
+    needs:
+      - bundle
+      - common
+    defaults:
+      run:
+        working-directory: esphome
+    steps:
+      - name: Download prepared repository
+        uses: pyTooling/download-artifact@v8
+        with:
+          name: bundle
+          path: .
+      - name: Update index to make "git diff-index" happy
+        run: git update-index -q --really-refresh
+
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+
+      - name: Cache platformio
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache@v5.0.4
+        with:
+          path: ~/.platformio
+          key: platformio-cpp-unit-tests-${{ hashFiles('esphome/platformio.ini') }}
+          restore-keys: platformio-cpp-unit-tests-
+
+      - name: Cache platformio
+        if: github.ref != 'refs/heads/main'
+        uses: actions/cache/restore@v5.0.4
+        with:
+          path: ~/.platformio
+          key: platformio-cpp-unit-tests-${{ hashFiles('esphome/platformio.ini') }}
+          restore-keys: platformio-cpp-unit-tests-
+
+      - name: Run C++ unit tests
+        run: |
+          . venv/bin/activate
+          script/cpp_unit_test.py virtual_can_bms
+        env:
+          PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
+          ASAN_OPTIONS: detect_leaks=0
+
   esphome-config:
     name: Validate example configurations
     runs-on: ubuntu-24.04

--- a/components/virtual_can_bms/virtual_can_bms.cpp
+++ b/components/virtual_can_bms/virtual_can_bms.cpp
@@ -76,9 +76,9 @@ void VirtualCanBms::send_frame_0x0355_() {
     return;
   }
 
-  message.StateOfCharge = state_of_charge;    // 0%...100%
-  message.StateOfHealth = state_of_health;    // 0%...100%
-  message.StateOfChargeHighRes =              // 0.00%...100.00%, 0xFFFF = invalid
+  message.StateOfCharge = state_of_charge;  // 0%...100%
+  message.StateOfHealth = state_of_health;  // 0%...100%
+  message.StateOfChargeHighRes =            // 0.00%...100.00%, 0xFFFF = invalid
       (this->hires_state_of_charge_sensor_ != nullptr) ? static_cast<uint16_t>(hires_state_of_charge * 100.0f) : 0xFFFF;
 
   auto *ptr = reinterpret_cast<uint8_t *>(&message);

--- a/components/virtual_can_bms/virtual_can_bms.cpp
+++ b/components/virtual_can_bms/virtual_can_bms.cpp
@@ -63,21 +63,23 @@ void VirtualCanBms::send_frame_0x0355_() {
     return;
   }
 
-  float hires_state_of_charge = 65535;  // Invalid unsigned. Unused fields of used frames must set to "invalid"
-  if (this->hires_state_of_charge_sensor_ != nullptr) {
-    hires_state_of_charge = this->hires_state_of_charge_sensor_->get_state();
-  }
-
   float state_of_charge = this->state_of_charge_sensor_->get_state();
   float state_of_health = this->state_of_health_sensor_->get_state();
-  if (std::isnan(state_of_charge) || std::isnan(state_of_health) || std::isnan(hires_state_of_charge)) {
+
+  float hires_state_of_charge = NAN;
+  if (this->hires_state_of_charge_sensor_ != nullptr)
+    hires_state_of_charge = this->hires_state_of_charge_sensor_->get_state();
+
+  if (std::isnan(state_of_charge) || std::isnan(state_of_health) ||
+      (this->hires_state_of_charge_sensor_ != nullptr && std::isnan(hires_state_of_charge))) {
     ESP_LOGW(TAG, "One of the required sensor states is NaN. Unable to populate 0x0355 frame. Skipped");
     return;
   }
 
-  message.StateOfCharge = state_of_charge;                          // 0%...100%
-  message.StateOfHealth = state_of_health;                          // 0%...100%
-  message.StateOfChargeHighRes = (hires_state_of_charge * 100.0f);  // 0.00%...100.00%
+  message.StateOfCharge = state_of_charge;    // 0%...100%
+  message.StateOfHealth = state_of_health;    // 0%...100%
+  message.StateOfChargeHighRes =              // 0.00%...100.00%, 0xFFFF = invalid
+      (this->hires_state_of_charge_sensor_ != nullptr) ? static_cast<uint16_t>(hires_state_of_charge * 100.0f) : 0xFFFF;
 
   auto *ptr = reinterpret_cast<uint8_t *>(&message);
   this->canbus->send_data(0x0355, false, false, std::vector<uint8_t>(ptr, ptr + sizeof message));

--- a/tests/components/virtual_can_bms/common.h
+++ b/tests/components/virtual_can_bms/common.h
@@ -1,0 +1,32 @@
+#pragma once
+#include <cstdint>
+#include <map>
+#include <vector>
+#include "esphome/components/canbus/canbus.h"
+#include "esphome/components/virtual_can_bms/virtual_can_bms.h"
+
+namespace esphome::virtual_can_bms::testing {
+
+struct MockCanbus : canbus::Canbus {
+  struct Frame {
+    std::vector<uint8_t> data;
+  };
+  std::map<uint32_t, Frame> frames;
+
+  bool setup_internal() override { return true; }
+  canbus::Error send_message(canbus::CanFrame *frame) override {
+    frames[frame->can_id].data.assign(frame->data, frame->data + frame->can_data_length_code);
+    return canbus::Error::ERROR_OK;
+  }
+  canbus::Error read_message(canbus::CanFrame *frame) override { return canbus::Error::ERROR_NOMSG; }
+};
+
+class TestableVirtualCanBms : public VirtualCanBms {
+ public:
+  using VirtualCanBms::send_frame_0x0351_;
+  using VirtualCanBms::send_frame_0x0355_;
+  using VirtualCanBms::send_frame_0x0356_;
+  using VirtualCanBms::send_frame_0x035a_;
+};
+
+}  // namespace esphome::virtual_can_bms::testing

--- a/tests/components/virtual_can_bms/test.host.yaml
+++ b/tests/components/virtual_can_bms/test.host.yaml
@@ -1,0 +1,5 @@
+sensor:
+  - platform: template
+    id: dummy_sensor
+    update_interval: 60s
+    lambda: "return 0.0f;"

--- a/tests/components/virtual_can_bms/virtual_can_bms_test.cpp
+++ b/tests/components/virtual_can_bms/virtual_can_bms_test.cpp
@@ -1,0 +1,233 @@
+#include <gtest/gtest.h>
+#include "esphome/components/sensor/sensor.h"
+#include "common.h"
+
+namespace esphome::virtual_can_bms::testing {
+
+class VirtualCanBmsTest : public ::testing::Test {
+ protected:
+  MockCanbus canbus_;
+  TestableVirtualCanBms bms_;
+
+  sensor::Sensor charge_voltage_;
+  sensor::Sensor charge_current_limit_;
+  sensor::Sensor discharge_current_limit_;
+  sensor::Sensor discharge_voltage_limit_;
+  sensor::Sensor state_of_charge_;
+  sensor::Sensor state_of_health_;
+  sensor::Sensor hires_state_of_charge_;
+  sensor::Sensor battery_voltage_;
+  sensor::Sensor battery_current_;
+  sensor::Sensor battery_temperature_;
+
+  void SetUp() override {
+    bms_.set_canbus(&canbus_);
+    bms_.set_charge_voltage_sensor(&charge_voltage_);
+    bms_.set_charge_current_limit_sensor(&charge_current_limit_);
+    bms_.set_discharge_current_limit_sensor(&discharge_current_limit_);
+    bms_.set_discharge_voltage_limit_sensor(&discharge_voltage_limit_);
+    bms_.set_state_of_charge_sensor(&state_of_charge_);
+    bms_.set_state_of_health_sensor(&state_of_health_);
+    bms_.set_hires_state_of_charge_sensor(&hires_state_of_charge_);
+    bms_.set_battery_voltage_sensor(&battery_voltage_);
+    bms_.set_battery_current_sensor(&battery_current_);
+    bms_.set_battery_temperature_sensor(&battery_temperature_);
+  }
+};
+
+// ── Frame 0x0351 ──────────────────────────────────────────────────────────────
+
+TEST_F(VirtualCanBmsTest, Frame0x0351ChargeVoltage) {
+  charge_voltage_.publish_state(54.4f);
+  charge_current_limit_.publish_state(50.0f);
+  discharge_current_limit_.publish_state(50.0f);
+  discharge_voltage_limit_.publish_state(46.0f);
+  bms_.send_frame_0x0351_();
+
+  // ChargeVoltage = 54.4 * 10 = 544 = 0x0220 → [0x20, 0x02]
+  ASSERT_EQ(canbus_.frames[0x0351].data.size(), 8u);
+  EXPECT_EQ(canbus_.frames[0x0351].data[0], 0x20);
+  EXPECT_EQ(canbus_.frames[0x0351].data[1], 0x02);
+}
+
+TEST_F(VirtualCanBmsTest, Frame0x0351ChargeCurrent) {
+  charge_voltage_.publish_state(54.4f);
+  charge_current_limit_.publish_state(50.0f);
+  discharge_current_limit_.publish_state(50.0f);
+  discharge_voltage_limit_.publish_state(46.0f);
+  bms_.send_frame_0x0351_();
+
+  // MaxChargingCurrent = 50.0 * 10 = 500 = 0x01F4 → [0xF4, 0x01]
+  EXPECT_EQ(canbus_.frames[0x0351].data[2], 0xF4);
+  EXPECT_EQ(canbus_.frames[0x0351].data[3], 0x01);
+}
+
+TEST_F(VirtualCanBmsTest, Frame0x0351DischargeCurrent) {
+  charge_voltage_.publish_state(54.4f);
+  charge_current_limit_.publish_state(50.0f);
+  discharge_current_limit_.publish_state(50.0f);
+  discharge_voltage_limit_.publish_state(46.0f);
+  bms_.send_frame_0x0351_();
+
+  // MaxDischargingCurrent = 50.0 * 10 = 500 = 0x01F4 → [0xF4, 0x01]
+  EXPECT_EQ(canbus_.frames[0x0351].data[4], 0xF4);
+  EXPECT_EQ(canbus_.frames[0x0351].data[5], 0x01);
+}
+
+TEST_F(VirtualCanBmsTest, Frame0x0351DischargeVoltageLimit) {
+  charge_voltage_.publish_state(54.4f);
+  charge_current_limit_.publish_state(50.0f);
+  discharge_current_limit_.publish_state(50.0f);
+  discharge_voltage_limit_.publish_state(46.0f);
+  bms_.send_frame_0x0351_();
+
+  // DischargeVoltageLimit = 46.0 * 10 = 460 = 0x01CC → [0xCC, 0x01]
+  EXPECT_EQ(canbus_.frames[0x0351].data[6], 0xCC);
+  EXPECT_EQ(canbus_.frames[0x0351].data[7], 0x01);
+}
+
+TEST_F(VirtualCanBmsTest, Frame0x0351SkippedOnNaN) {
+  charge_voltage_.publish_state(NAN);
+  charge_current_limit_.publish_state(50.0f);
+  discharge_current_limit_.publish_state(50.0f);
+  discharge_voltage_limit_.publish_state(46.0f);
+  bms_.send_frame_0x0351_();
+
+  EXPECT_EQ(canbus_.frames.count(0x0351), 0u);
+}
+
+// ── Frame 0x0355 ──────────────────────────────────────────────────────────────
+
+TEST_F(VirtualCanBmsTest, Frame0x0355StateOfCharge) {
+  state_of_charge_.publish_state(85.0f);
+  state_of_health_.publish_state(100.0f);
+  hires_state_of_charge_.publish_state(85.50f);
+  bms_.send_frame_0x0355_();
+
+  // StateOfCharge = 85 = 0x0055 → [0x55, 0x00]
+  ASSERT_EQ(canbus_.frames[0x0355].data.size(), 6u);
+  EXPECT_EQ(canbus_.frames[0x0355].data[0], 0x55);
+  EXPECT_EQ(canbus_.frames[0x0355].data[1], 0x00);
+}
+
+TEST_F(VirtualCanBmsTest, Frame0x0355StateOfHealth) {
+  state_of_charge_.publish_state(85.0f);
+  state_of_health_.publish_state(100.0f);
+  hires_state_of_charge_.publish_state(85.50f);
+  bms_.send_frame_0x0355_();
+
+  // StateOfHealth = 100 = 0x0064 → [0x64, 0x00]
+  EXPECT_EQ(canbus_.frames[0x0355].data[2], 0x64);
+  EXPECT_EQ(canbus_.frames[0x0355].data[3], 0x00);
+}
+
+TEST_F(VirtualCanBmsTest, Frame0x0355HiresStateOfCharge) {
+  state_of_charge_.publish_state(85.0f);
+  state_of_health_.publish_state(100.0f);
+  hires_state_of_charge_.publish_state(85.50f);
+  bms_.send_frame_0x0355_();
+
+  // HiresSOC = 85.50 * 100 = 8550 = 0x2166 → [0x66, 0x21]
+  EXPECT_EQ(canbus_.frames[0x0355].data[4], 0x66);
+  EXPECT_EQ(canbus_.frames[0x0355].data[5], 0x21);
+}
+
+TEST_F(VirtualCanBmsTest, Frame0x0355HiresInvalidWhenNotConfigured) {
+  TestableVirtualCanBms bms_no_hires;
+  bms_no_hires.set_canbus(&canbus_);
+  bms_no_hires.set_state_of_charge_sensor(&state_of_charge_);
+  bms_no_hires.set_state_of_health_sensor(&state_of_health_);
+  state_of_charge_.publish_state(85.0f);
+  state_of_health_.publish_state(100.0f);
+  bms_no_hires.send_frame_0x0355_();
+
+  // HiresSOC = 65535 = 0xFFFF → [0xFF, 0xFF]
+  ASSERT_EQ(canbus_.frames[0x0355].data.size(), 6u);
+  EXPECT_EQ(canbus_.frames[0x0355].data[4], 0xFF);
+  EXPECT_EQ(canbus_.frames[0x0355].data[5], 0xFF);
+}
+
+TEST_F(VirtualCanBmsTest, Frame0x0355SkippedOnNaN) {
+  state_of_charge_.publish_state(NAN);
+  state_of_health_.publish_state(100.0f);
+  bms_.send_frame_0x0355_();
+
+  EXPECT_EQ(canbus_.frames.count(0x0355), 0u);
+}
+
+// ── Frame 0x0356 ──────────────────────────────────────────────────────────────
+
+TEST_F(VirtualCanBmsTest, Frame0x0356BatteryVoltage) {
+  battery_voltage_.publish_state(52.5f);
+  battery_current_.publish_state(-3.1f);
+  battery_temperature_.publish_state(25.0f);
+  bms_.send_frame_0x0356_();
+
+  // BatteryVoltage = 52.5 * 100 = 5250 = 0x1482 → [0x82, 0x14]
+  ASSERT_EQ(canbus_.frames[0x0356].data.size(), 6u);
+  EXPECT_EQ(canbus_.frames[0x0356].data[0], 0x82);
+  EXPECT_EQ(canbus_.frames[0x0356].data[1], 0x14);
+}
+
+TEST_F(VirtualCanBmsTest, Frame0x0356BatteryCurrentDischarging) {
+  battery_voltage_.publish_state(52.5f);
+  battery_current_.publish_state(-3.1f);
+  battery_temperature_.publish_state(25.0f);
+  bms_.send_frame_0x0356_();
+
+  // BatteryCurrent = -3.1 * 10 = -31 = 0xFFE1 → [0xE1, 0xFF]
+  EXPECT_EQ(canbus_.frames[0x0356].data[2], 0xE1);
+  EXPECT_EQ(canbus_.frames[0x0356].data[3], 0xFF);
+}
+
+TEST_F(VirtualCanBmsTest, Frame0x0356BatteryCurrentCharging) {
+  battery_voltage_.publish_state(52.5f);
+  battery_current_.publish_state(10.0f);
+  battery_temperature_.publish_state(25.0f);
+  bms_.send_frame_0x0356_();
+
+  // BatteryCurrent = 10.0 * 10 = 100 = 0x0064 → [0x64, 0x00]
+  EXPECT_EQ(canbus_.frames[0x0356].data[2], 0x64);
+  EXPECT_EQ(canbus_.frames[0x0356].data[3], 0x00);
+}
+
+TEST_F(VirtualCanBmsTest, Frame0x0356BatteryTemperature) {
+  battery_voltage_.publish_state(52.5f);
+  battery_current_.publish_state(-3.1f);
+  battery_temperature_.publish_state(25.0f);
+  bms_.send_frame_0x0356_();
+
+  // BatteryTemperature = 25.0 * 10 = 250 = 0x00FA → [0xFA, 0x00]
+  EXPECT_EQ(canbus_.frames[0x0356].data[4], 0xFA);
+  EXPECT_EQ(canbus_.frames[0x0356].data[5], 0x00);
+}
+
+TEST_F(VirtualCanBmsTest, Frame0x0356SkippedWhenAllSensorsAbsent) {
+  TestableVirtualCanBms bms_no_bat;
+  bms_no_bat.set_canbus(&canbus_);
+  bms_no_bat.send_frame_0x0356_();
+
+  EXPECT_EQ(canbus_.frames.count(0x0356), 0u);
+}
+
+TEST_F(VirtualCanBmsTest, Frame0x0356SkippedOnNaN) {
+  battery_voltage_.publish_state(NAN);
+  battery_current_.publish_state(-3.1f);
+  battery_temperature_.publish_state(25.0f);
+  bms_.send_frame_0x0356_();
+
+  EXPECT_EQ(canbus_.frames.count(0x0356), 0u);
+}
+
+// ── Frame 0x035A ──────────────────────────────────────────────────────────────
+
+TEST_F(VirtualCanBmsTest, Frame0x035AAlwaysZero) {
+  bms_.send_frame_0x035a_();
+
+  ASSERT_EQ(canbus_.frames[0x035A].data.size(), 8u);
+  for (auto byte : canbus_.frames[0x035A].data) {
+    EXPECT_EQ(byte, 0x00);
+  }
+}
+
+}  // namespace esphome::virtual_can_bms::testing


### PR DESCRIPTION
Tests verify SMA CAN frame encoding (0x0351, 0x0355, 0x0356, 0x035A) including float-to-integer scaling, signed/unsigned values, NaN skipping, and absent-sensor handling. MockCanbus captures send_data calls for assertion.