### PR TITLE
Move minimum ESPHome version requirement into validator

### DIFF
--- a/components/virtual_can_bms/__init__.py
+++ b/components/virtual_can_bms/__init__.py
@@ -40,6 +40,7 @@ VirtualCanBms = virtual_can_bms_ns.class_(
 )
 
 CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2025, 11, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(VirtualCanBms),

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -4,7 +4,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp32:
   board: wemos_d1_mini32

--- a/tests/esp32-can-rx.yaml
+++ b/tests/esp32-can-rx.yaml
@@ -3,7 +3,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp32:
   board: wemos_d1_mini32

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -6,7 +6,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.6.0
 
 esp32:
   board: esp32-c6-devkitc-1


### PR DESCRIPTION
Removes `min_version` from all YAML configurations and enforces the version constraint via `cv.require_esphome_version()` in the component schema instead.

## Changes

- Add `cv.require_esphome_version(2024, 12, 0)` as the first validator in `CONFIG_SCHEMA`
- Remove `min_version` from `esp32-example.yaml`, `tests/esp32-can-rx.yaml`, and `tests/esp32c6-compatibility-test.yaml`

## Why

Keeping the version requirement in the Python schema is the canonical approach for ESPHome components — it produces a clear validation error at config parse time rather than relying on a YAML-level hint that is easily overlooked or omitted in user configs.